### PR TITLE
generateNix: force using https URLs

### DIFF
--- a/lib/generateNix.js
+++ b/lib/generateNix.js
@@ -42,6 +42,7 @@ function prefetchgit(url, rev) {
 }
 
 function fetchgit(fileName, url, rev, branch, builtinFetchGit, actualName) {
+  url = url.replace(/^git:\/\/github/, 'https://github')
   const prefetched = prefetchgit(url, rev)
   const packageJSON = JSON.parse(
     fs.readFileSync(`${prefetched.path}/package.json`),


### PR DESCRIPTION
This is because GitHub has deprecated the unsecured `git://` access[1].
By regenerating our internal `yarn.nix` I confirmed that there are no
hash-changes, so this should be fully backwards-compatible.

[1] https://github.blog/2021-09-01-improving-git-protocol-security-github/